### PR TITLE
Fix date placeholders

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,13 +12,16 @@ const unicodeTo = 'ȦƁƇḒḖƑƓĦĪĴĶĿḾȠǾƤɊŘŞŦŬṼẆẊẎẐ�
 const mirrorFrom = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+\\|`~[{]};:\'",<.>/?';
 const mirrorTo = 'ɐqɔpǝɟƃɥıɾʞʅɯuodbɹsʇnʌʍxʎz∀ԐↃᗡƎℲ⅁HIſӼ⅂WNOԀÒᴚS⊥∩ɅＭX⅄Z0123456789¡@#$%ᵥ⅋⁎)(-_=+\\|,~]}[{;:,„´>.</¿';
 
-// Currently matches:
-// %(placeholder)s
-// %(placeholder)d
-// %s %d
-// {foo}
+// Match simple sprintf placholders eg: %(placeholder)s, {foo}
+const sprintfRx = /(?:%\(|\{)([\S]+?)(?:\}|\)[sd]{1})/;
+// Match simple placeholders %s %d
+const percentRx = /%[sd]{1}/;
+// Match dates - E.g. %%Y-%%m-%%d
+const dateRx = /%%-?[a-zA-Z]{1}-%%-?[a-zA-Z]{1}-%%-?[a-zA-Z]{1}/;
 // HTML entities e.g: &nbsp;
-const placeholderRx = /(?:%\(|\{)([\S]+?)(?:\}|\)[sd])|%[sd]|&[^\s]+?;/g;
+const htmlEntityRx = /&[^\s]+?;/;
+
+const placeholderRx = new RegExp(`${sprintfRx.source}|${percentRx.source}|${dateRx.source}|${htmlEntityRx.source}`, 'g');
 const whitespaceRx = /^\s+$/m;
 
 function splitText(input) {

--- a/tests/mirror.test.js
+++ b/tests/mirror.test.js
@@ -13,6 +13,10 @@ describe('mirrorTransform()', () => {
     expect(mirrorTransform('foo %(whatever)s')).toEqual('%(whatever)s ooɟ');
   });
 
+  it('should not mangle a date placeholder', () => {
+    expect(mirrorTransform('foo %%Y-%%m-%%d')).toEqual('%%Y-%%m-%%d ooɟ');
+  });
+
   it('should not mangle a curly brace placeholder', () => {
     expect(mirrorTransform('Abuse Reports for {addon} ({num})')).toEqual('({num}) {addon} ɹoɟ sʇɹodǝᴚ ǝsnq∀');
   });

--- a/tests/unicode.test.js
+++ b/tests/unicode.test.js
@@ -10,6 +10,10 @@ describe('unicode()', () => {
     expect(unicodeTransform('foo %(whatever)s')).toEqual('ƒǿǿ %(whatever)s');
   });
 
+  it('should not mangle a date placeholder', () => {
+    expect(unicodeTransform('foo %%Y-%%m-%%d')).toEqual('ƒǿǿ %%Y-%%m-%%d');
+  });
+
   it('should not mangle HTML', () => {
     expect(unicodeTransform('foo <a href="#whatevs">bar</a>')).toEqual('ƒǿǿ <a href="#whatevs">ƀȧř</a>');
   });


### PR DESCRIPTION
Fixes #11 

I took the opportunity to split out the regexes to make future modifications more easy since clearly things like sprintf are very basic and we will likely want add more complete support.

The date regex is quite loose, if there's something more concrete and it's worth limiting down to specific characters I'd be happy to update this patch.